### PR TITLE
[DM-17021] Allow qserv_ functions to be called through TAP

### DIFF
--- a/kube/tap-deployment.yaml
+++ b/kube/tap-deployment.yaml
@@ -26,7 +26,7 @@ spec:
         env:
         - name: CATALINA_OPTS
           # Presto backend
-          value: "-Dqservuser.jdbc.username=TAP_SCHEMA -Dqservuser.jdbc.password= -Dqservuser.jdbc.driverClassName=com.facebook.presto.jdbc.PrestoDriver -Dqservuser.jdbc.url=jdbc:presto://dax-presto:8080/tap_schema -Dtapuser.jdbc.username=TAP_SCHEMA -Domit-alma-test=true -Dtapuser.jdbc.password= -Dtapuser.jdbc.driverClassName=com.facebook.presto.jdbc.PrestoDriver -Dtapuser.jdbc.url=jdbc:presto://dax-presto:8080/tap_schema -Dca.nrc.cadc.reg.client.RegistryClient.local=true -Duws.jdbc.username=postgres -Duws.jdbc.driverClassName=org.postgresql.Driver -Duws.jdbc.url=jdbc:postgresql://postgresql-service/"
+          value: "-Dqservuser.jdbc.username=qsmaster -Dqservuser.jdbc.password= -Dqservuser.jdbc.driverClassName=com.mysql.cj.jdbc.Driver -Dqservuser.jdbc.url=jdbc:mysql://qserv-master01:4040/ -Dtapuser.jdbc.username=TAP_SCHEMA -Domit-alma-test=true -Dtapuser.jdbc.password=TAP_SCHEMA -Dtapuser.jdbc.driverClassName=com.mysql.cj.jdbc.Driver -Dtapuser.jdbc.url=jdbc:mysql://tap-schema-service:3306/ -Dca.nrc.cadc.reg.client.RegistryClient.local=true -Duws.jdbc.username=postgres -Duws.jdbc.driverClassName=org.postgresql.Driver -Duws.jdbc.url=jdbc:postgresql://postgresql-service/"
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: "/etc/creds/google_creds.json"
       volumes:

--- a/src/main/java/org/opencadc/tap/impl/AdqlQueryImpl.java
+++ b/src/main/java/org/opencadc/tap/impl/AdqlQueryImpl.java
@@ -78,6 +78,7 @@ import ca.nrc.cadc.tap.parser.navigator.FromItemNavigator;
 import ca.nrc.cadc.tap.parser.navigator.ReferenceNavigator;
 import ca.nrc.cadc.tap.parser.navigator.SelectNavigator;
 import org.apache.log4j.Logger;
+import org.opencadc.tap.impl.QServRegionConverter;
 
 /**
  * TAP service implementors must implement this class and add customisations of the 
@@ -126,7 +127,6 @@ public class AdqlQueryImpl extends AdqlQuery
 
         TableNameReferenceConverter tnrc = new TableNameReferenceConverter(tnc.map);
         super.navigatorList.add(new SelectNavigator(new ExpressionNavigator(), tnrc, tnc));
-        
-        // TODO: add more custom query visitors here
+        super.navigatorList.add(new QServRegionConverter(new ExpressionNavigator(), new ReferenceNavigator(), new FromItemNavigator()));
     }
 }

--- a/src/main/java/org/opencadc/tap/impl/AdqlQueryImpl.java
+++ b/src/main/java/org/opencadc/tap/impl/AdqlQueryImpl.java
@@ -111,6 +111,9 @@ public class AdqlQueryImpl extends AdqlQuery
         tnc.put("tap_schema.columns", "tap_schema.columns11");
         tnc.put("tap_schema.keys", "tap_schema.keys11");
         tnc.put("tap_schema.key_columns", "tap_schema.key_columns11");
+
+        /* [DM-17021] Don't remap table names when connecting directly.
+         * This only needs to happen when we use presto.
         tnc.put("uws.job", "uws.uws.job");
         tnc.put("wise_00.allsky_2band_p1bm_frm", "qserv.wise_00.allsky_2band_p1bm_frm");
         tnc.put("wise_00.allsky_3band_p1bm_frm", "qserv.wise_00.allsky_3band_p1bm_frm");
@@ -119,6 +122,7 @@ public class AdqlQueryImpl extends AdqlQuery
         tnc.put("wise_00.allwise_p3as_cdd", "qserv.wise_00.allwise_p3as_cdd");
         tnc.put("wise_00.allwise_p3as_mep", "qserv.wise_00.allwise_p3as_mep");
         tnc.put("wise_00.allwise_p3as_psd", "qserv.wise_00.allwise_p3as_psd");
+         */
 
         TableNameReferenceConverter tnrc = new TableNameReferenceConverter(tnc.map);
         super.navigatorList.add(new SelectNavigator(new ExpressionNavigator(), tnrc, tnc));

--- a/src/main/java/org/opencadc/tap/impl/QServRegionConverter.java
+++ b/src/main/java/org/opencadc/tap/impl/QServRegionConverter.java
@@ -1,0 +1,40 @@
+package org.opencadc.tap.impl;
+
+import ca.nrc.cadc.tap.parser.navigator.ExpressionNavigator;
+import ca.nrc.cadc.tap.parser.navigator.FromItemNavigator;
+import ca.nrc.cadc.tap.parser.navigator.ReferenceNavigator;
+import ca.nrc.cadc.tap.parser.RegionFinder;
+
+import net.sf.jsqlparser.expression.Expression;
+
+import org.apache.log4j.Logger;
+
+import ca.nrc.cadc.tap.parser.navigator.SelectNavigator;
+
+/**
+ * This class implements the rewriting of all ADQL geometry constructs
+ * as QServ specific geometry functions.  This extends the RegionFinder,
+ * which by default for functions not overridden in this class throws
+ * UnsupportedOperationException.
+ *
+ * @author cbanek
+ */
+
+public class QServRegionConverter extends RegionFinder
+{
+    private static Logger log = Logger.getLogger(QServRegionConverter.class);
+
+    public QServRegionConverter(ExpressionNavigator en, ReferenceNavigator rn, FromItemNavigator fn)
+    {
+        super(en, rn, fn);
+    }
+
+    /**
+     * This method is called when a CIRCLE geometry value is found.
+     */
+    @Override
+    protected Expression handleCircle(Expression coordsys, Expression ra, Expression dec, Expression radius)
+    {
+        throw new UnsupportedOperationException("Christine needs to write CIRCLE");
+    }
+}

--- a/src/main/java/org/opencadc/tap/schema/ALMATapSchemaDAO.java
+++ b/src/main/java/org/opencadc/tap/schema/ALMATapSchemaDAO.java
@@ -97,11 +97,21 @@ public class ALMATapSchemaDAO extends TapSchemaDAO {
         functionDescs.add(new FunctionDesc("COALESCE", TapDataType.FUNCTION_ARG));
         functionDescs.add(new FunctionDesc("CONCAT", TapDataType.CHAR));
 
+        // Add BOX for ADQL.
+        functionDescs.add(new FunctionDesc("BOX", new TapDataType("double", "5", "box")));
+
         // QServ specific functions.
-        functionDescs.add(new FunctionDesc("qserv_areaspec_circle", TapDataType.DOUBLE));
+        functionDescs.add(new FunctionDesc("qserv_areaspec_box", TapDataType.INTEGER));
+        functionDescs.add(new FunctionDesc("qserv_areaspec_circle", TapDataType.INTEGER));
+        functionDescs.add(new FunctionDesc("qserv_areaspec_ellipse", TapDataType.INTEGER));
+        functionDescs.add(new FunctionDesc("qserv_areaspec_poly", TapDataType.INTEGER));
 
         // SciSQL specific functions.
         functionDescs.add(new FunctionDesc("scisql_angSep", TapDataType.DOUBLE));
+        functionDescs.add(new FunctionDesc("scisql_s2PtInBox", TapDataType.INTEGER));
+        functionDescs.add(new FunctionDesc("scisql_s2PtInCPoly", TapDataType.INTEGER));
+        functionDescs.add(new FunctionDesc("scisql_s2PtInCircle", TapDataType.INTEGER));
+        functionDescs.add(new FunctionDesc("scisql_s2PtInEllipse", TapDataType.INTEGER));
 
         return functionDescs;
     }

--- a/src/main/java/org/opencadc/tap/schema/ALMATapSchemaDAO.java
+++ b/src/main/java/org/opencadc/tap/schema/ALMATapSchemaDAO.java
@@ -97,6 +97,12 @@ public class ALMATapSchemaDAO extends TapSchemaDAO {
         functionDescs.add(new FunctionDesc("COALESCE", TapDataType.FUNCTION_ARG));
         functionDescs.add(new FunctionDesc("CONCAT", TapDataType.CHAR));
 
+        // QServ specific functions.
+        functionDescs.add(new FunctionDesc("qserv_areaspec_circle", TapDataType.DOUBLE));
+
+        // SciSQL specific functions.
+        functionDescs.add(new FunctionDesc("scisql_angSep", TapDataType.DOUBLE));
+
         return functionDescs;
     }
 }

--- a/src/main/webapp/capabilities.xml
+++ b/src/main/webapp/capabilities.xml
@@ -105,6 +105,9 @@
                 <form>POINT</form>
             </feature>
             <feature>
+                <form>BOX</form>
+            </feature>
+            <feature>
                 <form>CIRCLE</form>
             </feature>
             <feature>


### PR DESCRIPTION
This allows for all the normal qserv_areaspec_* and scisql functions to be called through the TAP service.  In this, we get rid of Presto from the mix (because it doesn't pass down UDFs), whitelist the UDF names, and additionally wire up the ADQL parser (although there's no implementation yet).