### PR TITLE
[DM-17455] Fix availability endpoint.

### DIFF
--- a/src/main/java/org/opencadc/tap/ws/TAPWebService.java
+++ b/src/main/java/org/opencadc/tap/ws/TAPWebService.java
@@ -85,12 +85,10 @@ import org.apache.log4j.Logger;
 public class TAPWebService implements AvailabilityPlugin {
     private static final Logger log = Logger.getLogger(TAPWebService.class);
 
-    private final static String OMIT_ALMA_TEST_PROPERTY = "omit-alma-test";
     private final static String TAPDS_NAME = "jdbc/tapuser";
     // note tap_schema table names
     private final static String TAPDS_TEST =
-        "select SCHEMA_NAME from TAP_SCHEMA.SCHEMAS11 where SCHEMA_NAME='TAP_SCHEMA'";
-    private final static String ALMA_TEST = "select DATASET_ID from ALMA.ASA_SCIENCE where ROWNUM = 1";
+        "select SCHEMA_NAME from tap_schema.schemas11 where SCHEMA_NAME='TAP_SCHEMA'";
 
     private String applicationName;
 
@@ -117,11 +115,6 @@ public class TAPWebService implements AvailabilityPlugin {
         try {
             // Test query using standard TAP data source
             check(TAPDS_TEST);
-
-            // Won't run in Travis.
-            if (!omitALMATest()) {
-                check(ALMA_TEST);
-            }
         } catch (CheckException ce) {
             // tests determined that the resource is not working
             isGood = false;
@@ -137,14 +130,6 @@ public class TAPWebService implements AvailabilityPlugin {
 
     private void check(final String query) throws CheckException {
         new CheckDataSource(TAPDS_NAME, query).check();
-    }
-
-    /**
-     * Omit this test in Travis since the ALMA database is unreachable.
-     * @return  True if the omit-alma-test system property is set.
-     */
-    private boolean omitALMATest() {
-        return Boolean.parseBoolean(System.getProperty(OMIT_ALMA_TEST_PROPERTY));
     }
 
     @Override

--- a/src/main/webapp/META-INF/context.xml
+++ b/src/main/webapp/META-INF/context.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <Context>
     <WatchedResource>WEB-INF/web.xml</WatchedResource>
-       
+
     <Resource name="jdbc/tapuser"
               auth="Container"
               type="javax.sql.DataSource"
@@ -18,7 +18,7 @@
               validationQuery="SELECT 1"
               defaultAutoCommit="true"
     />
-    
+
     <Resource name="jdbc/qservuser"
               auth="Container"
               type="javax.sql.DataSource"


### PR DESCRIPTION
The availability endpoint was giving a SQL exception running
the query against TAP_SCHEMA.  This is because this goes through
a different call path that doesn't lowercase all the table names,
and mysql is sadly case sensitive as to table names.  So make
the table names lowercase, and get rid of some of the additional
ALMA checking.

Also get rid of some trailing whitespace in the context.xml file.

With this, the availability endpoint says everything is well.