### PR TITLE
[DM-18451] Update schema_index for schemas.

### DIFF
--- a/docker/tap-schema/0005_tap_schema_self11.sql
+++ b/docker/tap-schema/0005_tap_schema_self11.sql
@@ -33,8 +33,8 @@ delete from tap_schema.schemas11 where lower(schema_name) = 'tap_schema'
 ;
 
 
-insert into tap_schema.schemas11 (schema_name,description,utype) values
-( 'tap_schema', 'a special schema to describe TAP-1.1 tablesets', NULL )
+insert into tap_schema.schemas11 (schema_name,description,utype,schema_index) values
+( 'tap_schema', 'a special schema to describe TAP-1.1 tablesets', NULL, 10)
 ;
 
 insert into tap_schema.tables11 (schema_name,table_name,table_type,description,utype,table_index) values

--- a/docker/tap-schema/1000_table_create.sql
+++ b/docker/tap-schema/1000_table_create.sql
@@ -28,8 +28,8 @@ CREATE TABLE tap_schema.obscore
    PRIMARY KEY (obs_publisher_did)
 );
 
-INSERT INTO tap_schema.schemas11 (schema_name, description, utype)
-  VALUES ('SYS', 'An Oracle system schema', NULL);
+INSERT INTO tap_schema.schemas11 (schema_name, description, utype, schema_index)
+  VALUES ('SYS', 'An Oracle system schema', NULL, 100);
 
 INSERT INTO tap_schema.tables11 (schema_name, table_name, table_type, description, utype, table_index)
   VALUES ('tap_schema', 'tap_schema.obscore', 'table', 'description of schemas in this tableset', NULL, 1);

--- a/docker/tap-schema/1002_gaia_source.sql
+++ b/docker/tap-schema/1002_gaia_source.sql
@@ -21,8 +21,8 @@ CREATE TABLE gaiadr2.gaia_source
 GRANT SELECT ON gaiadr2.* TO 'TAP_SCHEMA'@'%';
 
 -- Insert the tap_schema metadata about this table and its columns.
-INSERT INTO tap_schema.schemas11 (schema_name, description, utype)
-  VALUES ('gaiadr2', 'Gaia DR2', NULL);
+INSERT INTO tap_schema.schemas11 (schema_name, description, utype, schema_index)
+  VALUES ('gaiadr2', 'Gaia DR2', NULL, 100);
 
 INSERT INTO tap_schema.tables11 (schema_name, table_name, table_type, description, utype, table_index)
   VALUES ('gaiadr2', 'gaiadr2.gaia_source', 'table', 'GAIA source table.', NULL, 1);

--- a/docker/tap-schema/1003_uws_tap_schema.sql
+++ b/docker/tap-schema/1003_uws_tap_schema.sql
@@ -4,8 +4,8 @@ DELETE FROM tap_schema.tables11 where table_name like 'uws.Job';
 DELETE FROM tap_schema.schemas11 where schema_name like 'uws';
 
 -- Insert the tap_schema metadata about this table and its columns.
-INSERT INTO tap_schema.schemas11 (schema_name, description, utype)
-  VALUES ('uws', 'UWS Metadata', NULL);
+INSERT INTO tap_schema.schemas11 (schema_name, description, utype, schema_index)
+  VALUES ('uws', 'UWS Metadata', NULL, 100);
 
 INSERT INTO tap_schema.tables11 (schema_name, table_name, table_type, description, utype, table_index)
   VALUES ('uws', 'uws.Job', 'table', 'Job history table.', NULL, 1);


### PR DESCRIPTION
Order UWS, Gaia, and tap_schema lower than SDSS and wise.

For some reason, TOPCAT doesn't seem to respect the schema
index ordering.  But the schema index is set.