### PR TITLE
[DM-19340] Add count query to monkey queries

### DIFF
--- a/integration_test/querymonkey/test_queries/count.sql
+++ b/integration_test/querymonkey/test_queries/count.sql
@@ -1,0 +1,1 @@
+SELECT 'monkey', COUNT(*) FROM sdss_stripe82_01.RunDeepSource

--- a/integration_test/querymonkey/test_queries/neighbor.sql
+++ b/integration_test/querymonkey/test_queries/neighbor.sql
@@ -1,4 +1,4 @@
-SELECT o1.id AS id1, o2.id AS id2,
+SELECT 'monkey', o1.id AS id1, o2.id AS id2,
   DISTANCE(POINT('ICRS', o1.coord_ra, o1.coord_decl), POINT('ICRS', o2.coord_ra, o2.coord_decl)) AS d
 FROM sdss_stripe82_01.RunDeepSource o1, sdss_stripe82_01.RunDeepSource o2
 WHERE CONTAINS(POINT('ICRS', o1.coord_ra, o1.coord_decl), CIRCLE('ICRS', {{ ra }}, {{ dec }}, {{ r1 }})) = 1


### PR DESCRIPTION
COUNT(*) will hit all the workers, so by adding this query into the
mix we can verify all the workers are available and servicing queries
when this gets run.